### PR TITLE
test PR

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,39 +1,6 @@
 data "google_client_config" "default" {}
 
-resource "google_compute_instance" "vm_instance" {
-  name         = var.instance_name
-  machine_type = var.machine_type
-  zone         = var.zones
 
-  // Tags to receive firewall configurations
-  tags = var.firewall_target_tags
-
-  boot_disk {
-    initialize_params {
-      image = var.disk_image
-      size  = var.disk_size
-    }
-  }
-
-  network_interface {
-    network = var.network
-  }
-}
-
-resource "google_compute_instance_group" "ig_replicated_pov" {
-  name = var.instance_group_name
-
-  instances = [
-    google_compute_instance.vm_instance.id
-  ]
-
-  dynamic "named_port" {
-    for_each = var.named_ports
-    content {
-      name = named_port.value.name
-      port = named_port.value.port
-    }
-  }
 
   zone = var.zones
 }


### PR DESCRIPTION
### **User description**
Testing PR trigger for SKai


___

### **PR Type**
enhancement


___

### **Description**
- Removed the `google_compute_instance` resource, which included configurations for machine type, zone, tags, boot disk, and network interface.
- Removed the `google_compute_instance_group` resource, which included configurations for instance group name, instances, and dynamic named ports.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Remove compute instance and instance group resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<li>Removed <code>google_compute_instance</code> resource definition.<br> <li> Removed <code>google_compute_instance_group</code> resource definition.<br>


</details>


  </td>
  <td><a href="https://github.com/gmsopsf/skai-test/pull/1/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+0/-33</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

